### PR TITLE
feat(ocr): add traditional to simplified Chinese conversion

### DIFF
--- a/ocr.py
+++ b/ocr.py
@@ -9,6 +9,14 @@ from collections import defaultdict
 from tqdm import tqdm
 import paddle
 import threading
+from opencc import OpenCC
+
+class TraditionalToSimplified:
+    def __init__(self):
+        self.cc = OpenCC('t2s')
+
+    def Convert(self, text):
+        return self.cc.convert(text)
 
 class ImageConverter:
     def __init__(self, src_dir, dst_dir, num_threads=4) -> None:
@@ -121,6 +129,8 @@ class ImageProcessor:
 
         # 加载已处理文件列表
         self.file_count_map = FileNameCountMap(target_dir)
+        # 创建繁体转换类
+        self.traditional_to_simp = TraditionalToSimplified()
 
     def recognize_text(self, image_file):
         try:
@@ -146,6 +156,7 @@ class ImageProcessor:
 
             # 如果识别到文字，按要求重命名和移动文件
             if text and confidence:
+                text = self.traditional_to_simp.Convert(text)
                 new_filename = f"{text}_{self.file_count_map.GetValue(text)}.jpg"
                 confidence_level = str(int(confidence * 100 // 10 * 10))
                 target_path = os.path.join(self.target_dir, confidence_level, new_filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 paddlepaddle==2.5.2
 paddleocr==2.8.1
 pyheif==0.7.1
+opencc==1.1.6


### PR DESCRIPTION
Add functionality to convert recognized traditional Chinese text to simplified Chinese using OpenCC library. This enhances the OCR process by standardizing the output text format.

- Introduce TraditionalToSimplified class for text conversion
- Integrate conversion step in the text recognition process
- Update dependencies to include OpenCC

This change improves text consistency and searchability in the output files.